### PR TITLE
simpler 

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+    "base_dir": "/mnt/matsubara/sim_workspace",
     "grid": {
         "Nx": 2048,
         "Ny": 768,
@@ -32,6 +33,13 @@
         "glass": {
             "sound_speed": 5789,
             "density": 2240,
+            "alpha_coeff": 0.017,
+            "alpha_power": 2,
+            "BonA": 6
+        },
+        "steel": {
+            "sound_speed": 5850,
+            "density": 7850,
             "alpha_coeff": 0.017,
             "alpha_power": 2,
             "BonA": 6
@@ -90,11 +98,8 @@
         "pml_alpha": 2,
         "CFL": 0.03,
         "num_dataset": 10,
-        "num_particles": 46,
+        "num_particles": 6,
         "glass_radius": 1.25e-3,
         "distance_particles":0.25
-    },
-    "save_path": "/mnt/matsubara/rawdata",
-    "location_seedfiles_path": "/mnt/matsubara/location_seed",
-    "save_full_path":"/mnt/matsubara/tmp"
+    }
 } 

--- a/config.json
+++ b/config.json
@@ -22,6 +22,13 @@
             "alpha_power": 2,
             "BonA": 6
         },
+        "acrylic": {
+            "sound_speed": 2730,
+            "density": 1180,
+            "alpha_coeff": 0.17,
+            "alpha_power": 2,
+            "BonA": 6
+        },
         "glass": {
             "sound_speed": 5789,
             "density": 2240,
@@ -83,13 +90,11 @@
         "pml_alpha": 2,
         "CFL": 0.03,
         "num_dataset": 10,
-        "num_particles": 44,
+        "num_particles": 46,
         "glass_radius": 1.25e-3,
         "distance_particles":0.25
     },
     "save_path": "/mnt/matsubara/rawdata",
     "location_seedfiles_path": "/mnt/matsubara/location_seed",
-    "save_logs_path": "/mnt/matsubara/logs",
-    "save_data_path": "/mnt/matsubara/signals_sim",
     "save_full_path":"/mnt/matsubara/tmp"
 } 

--- a/data_generation.m
+++ b/data_generation.m
@@ -1,12 +1,13 @@
-function signalgen_module_all()
+function data_generation()
 % This function reads config.json and sequentially runs signalgen_module for all location1.csv, location2.csv, ... in the specified directory.
 
     % Path to config file
-    config_file = 'config.json';
+    script_dir = fileparts(mfilename('fullpath'));
+    config_file = fullfile(script_dir, 'config.json');
 
     % Get location_seedfiles_path from config.json
     config = jsondecode(fileread(config_file));
-    location_dir = config.location_seedfiles_path;
+    location_dir = fullfile(config.base_dir, 'location_seed');
 
     % Get all location*.csv files
     files = dir(fullfile(location_dir, 'location*.csv'));
@@ -15,7 +16,7 @@ function signalgen_module_all()
         error('No location*.csv files found in %s.', location_dir);
     end
     % Delete all files in the save_data_path directory before data generation
-    save_full_path = config.save_full_path;
+    save_full_path = fullfile(config.base_dir, 'tmp');
     save_data_path = fullfile(save_full_path, 'data');
     save_logs_path = fullfile(save_full_path, 'logs');
 
@@ -66,7 +67,6 @@ function signalgen_module_all()
     end
     % Run signalgen_module for each CSV file
     % Initialize (delete all files and folders) in save_full_path directory before data generation
-    save_full_path = config.save_full_path;
     if exist(save_full_path, 'dir')
         files_to_delete = dir(fullfile(save_full_path, '*'));
         for k = 1:length(files_to_delete)
@@ -90,23 +90,30 @@ function signalgen_module_all()
     end
 
     % Copy config.json file to save_full_path
-    config_file_src = config_file; % assuming config_file is the path to config.json
+    config_file_src = config_file; % already absolute (script-relative)
     config_file_dst = fullfile(save_full_path, 'config.json');
     copyfile(config_file_src, config_file_dst);
     fprintf('config.json has been copied to %s.\n', save_full_path);
 
-    % Copy location_seed folder to save_full_path
-    location_seed_src = config.location_seedfiles_path;
-    [~, location_seed_folder] = fileparts(location_seed_src);
-    location_seed_dst = fullfile(save_full_path, location_seed_folder);
-    if exist(location_seed_dst, 'dir')
-        rmdir(location_seed_dst, 's');
+    % Copy location_seed directory into save_full_path for reproducibility
+    location_dir_dst = fullfile(save_full_path, 'location_seed');
+    if exist(location_dir_dst, 'dir')
+        rmdir(location_dir_dst, 's');
     end
-    copyfile(location_seed_src, location_seed_dst);
-    fprintf('location_seed folder has been copied to %s.\n', save_full_path);
+    copyfile(location_dir, location_dir_dst);
+    fprintf('location_seed has been copied to %s.\n', location_dir_dst);
+
+    % Re-scan location*.csv from the copied folder
+    files = dir(fullfile(location_dir_dst, 'location*.csv'));
+    fprintf('--- %d location*.csv files found (copied). ---\n', length(files));
+    if isempty(files)
+        error('No location*.csv files found in %s.', location_dir_dst);
+    end
+
     for i = 1:length(files)
-        location_csv = fullfile(location_dir, files(i).name);
+        location_csv = fullfile(location_dir_dst, files(i).name);
         fprintf('--- Processing %s ---\n', location_csv);
-        simulation_execution(config_file, location_csv);
+        % Use the copied config for the simulation run
+        simulation_execution(config_file_dst, location_csv);
     end
 end

--- a/data_generation.m
+++ b/data_generation.m
@@ -15,8 +15,9 @@ function signalgen_module_all()
         error('No location*.csv files found in %s.', location_dir);
     end
     % Delete all files in the save_data_path directory before data generation
-    save_data_path = config.save_data_path;
-    save_logs_path = config.save_logs_path;
+    save_full_path = config.save_full_path;
+    save_data_path = fullfile(save_full_path, 'data');
+    save_logs_path = fullfile(save_full_path, 'logs');
 
     % Delete all files in the save_data_path directory before data generation
     if exist(save_data_path, 'dir')

--- a/kwavesim.m
+++ b/kwavesim.m
@@ -131,8 +131,8 @@ function kwavesim(config_file, location_csv, locnum_str)
     ringMask = (ring2d <= outer_r) & (ring2d >= inner_r);
 
     pipe_mask = repmat(ringMask, [1 1 Nz]);
-    medium.sound_speed(pipe_mask == 1) = config.medium.vinyl.sound_speed;
-    medium.density(pipe_mask == 1) = config.medium.vinyl.density;
+    medium.sound_speed(pipe_mask == 1) = config.medium.acrylic.sound_speed;
+    medium.density(pipe_mask == 1) = config.medium.acrylic.density;
 
     % Glass mask
     % Read coordinates from locationX.csv
@@ -169,10 +169,11 @@ function kwavesim(config_file, location_csv, locnum_str)
     scan_line = transducer_transmit.scan_line(sensor_data);
     figure(1);
     plot(kgrid.t_array * 1e6, scan_line * 1e-6, 'b-');
-    xlabel('Time [\mus]');
-    ylabel('Pressure [MPa]');
+    xlabel('Time [\mus]', 'FontSize', 18);
+    ylabel('Pressure [MPa]', 'FontSize', 18);
     ylim([-2 2]);
-    title('Signal from Transducer transmit');
+    title('Signal from Transducer transmit', 'FontSize', 20);
+    set(gca, 'FontSize', 16);
     grid on;
     saveas(gcf, fullfile(save_logs_path, ['signal_solid_liquid_reflector' locnum_str '.png']));
 
@@ -217,10 +218,11 @@ function kwavesim(config_file, location_csv, locnum_str)
     xlim([1, Nx]);
     ylim([1, Ny]);
     zlim([1, Nz]);
-    xlabel('X');
-    ylabel('Y');
-    zlabel('Z');
-    title('Transducer, Sensor, and Pipe Mask Visualization');
+    xlabel('X', 'FontSize', 18);
+    ylabel('Y', 'FontSize', 18);
+    zlabel('Z', 'FontSize', 18);
+    title('Transducer, Sensor, and Pipe Mask Visualization', 'FontSize', 20);
+    set(gca, 'FontSize', 16);
     view(80, 20);
     camlight;
     lighting gouraud;

--- a/kwavesim.m
+++ b/kwavesim.m
@@ -2,8 +2,22 @@ function kwavesim(config_file, location_csv, locnum_str)
 % Main simulation logic for k-Wave, extracted for modular use.
 
     config = jsondecode(fileread(config_file));
-    save_logs_path = fullfile(config.save_full_path, 'logs');
-    save_data_path = fullfile(config.save_full_path, 'data');
+    
+    % Decide base directory for saving data/logs
+    if isfield(config, 'save_full_path')
+        % Backward compatibility: use explicit path if provided
+        save_full_path = config.save_full_path;
+    elseif isfield(config, 'base_dir')
+        % Default: use base_dir/tmp
+        save_full_path = fullfile(config.base_dir, 'tmp');
+    else
+        % Final fallback: tmp under this script's directory
+        script_dir = fileparts(mfilename('fullpath'));
+        save_full_path = fullfile(script_dir, 'tmp');
+    end
+
+    save_logs_path = fullfile(save_full_path, 'logs');
+    save_data_path = fullfile(save_full_path, 'data');
     % Check if save_logs_path exists, and create it if it does not exist
     if ~exist(save_logs_path, 'dir')
         mkdir(save_logs_path);
@@ -131,9 +145,9 @@ function kwavesim(config_file, location_csv, locnum_str)
     ringMask = (ring2d <= outer_r) & (ring2d >= inner_r);
 
     pipe_mask = repmat(ringMask, [1 1 Nz]);
-    medium.sound_speed(pipe_mask == 1) = config.medium.acrylic.sound_speed;
-    medium.density(pipe_mask == 1) = config.medium.acrylic.density;
-
+    medium.sound_speed(pipe_mask == 1) = config.medium.steel.sound_speed;
+    medium.density(pipe_mask == 1) = config.medium.steel.density;
+    medium.alpha_coeff(pipe_mask == 1) = config.medium.steel.alpha_coeff;
     % Glass mask
     % Read coordinates from locationX.csv
     location = csvread(location_csv);

--- a/pipe_location_gen.m
+++ b/pipe_location_gen.m
@@ -13,11 +13,20 @@ for i = 1:num_repeat
         error('Configuration file not found: %s', config_file);
     end
     config = jsondecode(fileread(config_file));
-    save_path = config.location_seedfiles_path;
-    if ~exist(save_path, 'dir')
-        mkdir(save_path);
+    % Determine seedfiles_dir in a robust way
+    if isfield(config, 'seedfiles_dir')
+        seedfiles_dir = config.seedfiles_dir;
+    elseif isfield(config, 'base_dir')
+        seedfiles_dir = fullfile(config.base_dir, 'location_seed');
+    else
+        % Fallback: use directory of this script
+        script_dir = fileparts(mfilename('fullpath'));
+        seedfiles_dir = fullfile(script_dir, 'location_seed');
     end
-    filename = fullfile(save_path, sprintf('location%d.csv', i));
+    if ~exist(seedfiles_dir, 'dir')
+        mkdir(seedfiles_dir);
+    end
+    filename = fullfile(seedfiles_dir, sprintf('location%d.csv', i));
     writematrix(samples', filename); % Save as CSV (transpose to get m rows)
 end
 % XY plane scatter plot with unit circle
@@ -32,7 +41,7 @@ ylabel('Y');
 title('Sample points and unit circle in XY plane');
 grid on;
 axis equal;
-saveas(gcf, fullfile(save_path, 'pipeplot.png'));
+saveas(gcf, fullfile(seedfiles_dir, 'pipeplot.png'));
 
 % XZ plane projection (z from 0 to 1, square from -1 to 1 in X)
 figure;
@@ -47,7 +56,7 @@ ylabel('Z');
 title('Sample points and [0,1] square in XZ plane');
 grid on;
 axis equal;
-saveas(gcf, fullfile(save_path, 'pipeplot_xz.png'));
+saveas(gcf, fullfile(seedfiles_dir, 'pipeplot_xz.png'));
 
 % YZ plane projection (z from 0 to 1, square from -1 to 1 in Y)
 figure;
@@ -62,7 +71,7 @@ ylabel('Z');
 title('Sample points and [0,1] square in YZ plane');
 grid on;
 axis equal;
-saveas(gcf, fullfile(save_path, 'pipeplot_yz.png'));
+saveas(gcf, fullfile(seedfiles_dir, 'pipeplot_yz.png'));
 
 % 3D scatter plot with unit cylinder overlay
 figure;
@@ -84,8 +93,8 @@ title('3D sample points and unit cylinder');
 grid on;
 axis equal;
 hold off;
-saveas(gcf, fullfile(save_path, 'pipeplot_3d.png'));
-fprintf('plot saved to %s\n', save_path);
+saveas(gcf, fullfile(seedfiles_dir, 'pipeplot_3d.png'));
+fprintf('plot saved to %s\n', seedfiles_dir);
 % --- 関数定義部分（同じファイルの末尾、または別ファイルに分離）---
 function samples = glass_location_gen(m)
     % SAMPLING - Sample from 3D Gaussian distribution
@@ -96,8 +105,9 @@ function samples = glass_location_gen(m)
     % Outputs:
     %   samples - 3xm array containing the sampled points
     
-    % Read configuration file
-    config_file = 'config.json';
+    % Read configuration file (always relative to this script's directory)
+    script_dir = fileparts(mfilename('fullpath'));
+    config_file = fullfile(script_dir, 'config.json');
     if ~exist(config_file, 'file')
         error('Configuration file not found: %s', config_file);
     end
@@ -109,15 +119,19 @@ function samples = glass_location_gen(m)
     fclose(fid);
     config = jsondecode(str);
     
-    % Extract save path from configuration
-    if ~isfield(config, 'save_path')
-        error('save_path not found in configuration file');
+    % Extract save path from configuration (keep logic consistent with main script)
+    if isfield(config, 'seedfiles_dir')
+        seedfiles_dir = config.seedfiles_dir;
+    elseif isfield(config, 'base_dir')
+        seedfiles_dir = fullfile(config.base_dir, 'location_seed');
+    else
+        % Final fallback: use directory of this script
+        seedfiles_dir = fullfile(script_dir, 'location_seed');
     end
-    save_path = config.save_path;
     
     % Create save directory if it doesn't exist
-    if ~exist(save_path, 'dir')
-        mkdir(save_path);
+    if ~exist(seedfiles_dir, 'dir')
+        mkdir(seedfiles_dir);
     end
     
     % Sample from 3D Gaussian (mean 0, var 1), keep only those inside unit circle in XY plane,
@@ -166,7 +180,7 @@ function samples = glass_location_gen(m)
     end
     
     % Save samples to CSV file
-    csv_file = fullfile(save_path, 'sample.csv');
+    csv_file = fullfile(seedfiles_dir, 'sample.csv');
     sample_table = array2table(samples', 'VariableNames', {'X', 'Y', 'Z'});
     writetable(sample_table, csv_file);
 
@@ -190,7 +204,7 @@ function samples = glass_location_gen(m)
     % title('Sample points and unit circle in XY plane');
     % grid on;
     % axis equal;
-    % saveas(gcf, fullfile(save_path, 'pipeplot.png'));
+    % saveas(gcf, fullfile(seedfiles_dir, 'pipeplot.png'));
 
     % % XZ plane projection (z from 0 to 1, square from -1 to 1 in X)
     % figure;
@@ -205,7 +219,7 @@ function samples = glass_location_gen(m)
     % title('Sample points and [0,1] square in XZ plane');
     % grid on;
     % axis equal;
-    % saveas(gcf, fullfile(save_path, 'pipeplot_xz.png'));
+    % saveas(gcf, fullfile(seedfiles_dir, 'pipeplot_xz.png'));
 
     % % YZ plane projection (z from 0 to 1, square from -1 to 1 in Y)
     % figure;
@@ -220,7 +234,7 @@ function samples = glass_location_gen(m)
     % title('Sample points and [0,1] square in YZ plane');
     % grid on;
     % axis equal;
-    % saveas(gcf, fullfile(save_path, 'pipeplot_yz.png'));
+    % saveas(gcf, fullfile(seedfiles_dir, 'pipeplot_yz.png'));
 
     % % 3D scatter plot with unit cylinder overlay
     % figure;
@@ -242,8 +256,8 @@ function samples = glass_location_gen(m)
     % grid on;
     % axis equal;
     % hold off;
-    % saveas(gcf, fullfile(save_path, 'pipeplot_3d.png'));
-    % fprintf('plot saved to %s\n', save_path);
+    % saveas(gcf, fullfile(seedfiles_dir, 'pipeplot_3d.png'));
+    % fprintf('plot saved to %s\n', seedfiles_dir);
     % If you want to run the plotting script directly (optional, if available and path is correct):
     % try
     %     run(fullfile(fileparts(mfilename('fullpath')), 'tutorials', 'sampleplot.m'));
@@ -252,8 +266,4 @@ function samples = glass_location_gen(m)
     % end
 
 end
-% --- 英語での説明 ---
-% In MATLAB, you cannot define a function inside a script file and execute the script as a function.
-% To fix this, separate the script part (variable assignment and function call) from the function definition.
-% Place the function definition at the end of the file or in a separate file.
-% Then, run the script part to execute your code.
+


### PR DESCRIPTION
change config.json much more simpler and easier to modify, but the save rules have rigorously settled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect filesystem path resolution and where outputs/inputs are stored and deleted, which can break existing workflows or overwrite unexpected directories if `base_dir` is misconfigured. Simulation medium parameters for the pipe also change (vinyl→steel), affecting generated data.
> 
> **Overview**
> Simplifies `config.json` by introducing `base_dir`, removing multiple explicit save path fields, adding `acrylic`/`steel` media definitions, and reducing `simulation.num_particles` from 44 to 6.
> 
> Updates MATLAB scripts to derive `location_seed` and `tmp/{data,logs}` paths from `base_dir`, copy `config.json` and seed files into the run folder for reproducibility, and run simulations against the copied inputs. `kwavesim.m` now chooses a save root via `save_full_path` (legacy) or `base_dir/tmp`, applies `steel` properties to the pipe (including `alpha_coeff`), and tweaks plot font sizing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beeb9ac4c59d3ba2e3242dd11a4533e128b83910. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Refactor configuration and path handling to use script-relative config.json and a base_dir-driven directory structure for seed files, simulation data, and logs, while updating simulation media properties and plots accordingly.

New Features:
- Support deriving seed file, data, and log directories from a base_dir in config.json with sensible fallbacks to maintain backward compatibility.

Bug Fixes:
- Ensure config.json and output directories are resolved relative to the script location when explicit paths are not provided, preventing failures due to missing or incorrect working directories.

Enhancements:
- Unify and simplify the logic for locating and creating the location_seed directory across pipe location generation and sample-generation code.
- Standardize the simulation output root to a tmp directory under base_dir (or a compatible fallback) and copy config and seed files into it for reproducible runs.
- Update k-Wave simulation to use steel parameters for the pipe medium and include its attenuation coefficient, and improve plot readability via larger fonts and axis styling.